### PR TITLE
Fix HTML file detection when dots are in path

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -16,30 +16,7 @@ const parseUriField = uri => {
   return JSON.parse(fromBase64(uri.slice(1)));
 };
 
-const isHtml = urlStr => {
-  const parsedUrl = url.parse(urlStr);
-  const path = parsedUrl.pathname;
-  const basename = path.split("/").pop();
-
-  if (basename === "") return true;
-
-  // doesn't detect index.whatever.html (multiple dots)
-  const hasHtmlOrNoExtension = !!basename.match(/^(([^.]|\.html?)+)$/);
-
-  if (hasHtmlOrNoExtension) return true;
-
-  // hack to handle basenames with multiple dots: index.whatever.html
-  const endsInHtml = !!basename.match(/.html?$/);
-
-  if (endsInHtml) return true;
-
-  // hack to detect extensions that are not HTML so we can handle
-  // paths with dots in them
-  const endsInOtherExtension = basename.match(/\.[a-zA-Z]{1,5}$/);
-  if (!endsInOtherExtension) return true;
-
-  return false;
-};
+const isHtml = require("prerendercloud").util.urlPathIsHtml;
 
 module.exports = {
   USER_AGENT_PLACEHOLDER,

--- a/lib/util.js
+++ b/lib/util.js
@@ -33,7 +33,20 @@ const isHtml = urlStr => {
 
   if (endsInHtml) return true;
 
+  // hack to detect extensions that are not HTML so we can handle
+  // paths with dots in them
+  const endsInOtherExtension = basename.match(/\.[a-zA-Z]{1,5}$/);
+  if (!endsInOtherExtension) return true;
+
   return false;
 };
 
-module.exports = { USER_AGENT_PLACEHOLDER, toBase64, fromBase64, createUri, getHeader, parseUriField, isHtml };
+module.exports = {
+  USER_AGENT_PLACEHOLDER,
+  toBase64,
+  fromBase64,
+  createUri,
+  getHeader,
+  parseUriField,
+  isHtml
+};

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
     "serverless": "1.24.1"
   },
   "dependencies": {
-    "prerendercloud": "^1.23.2"
+    "prerendercloud": "1.27.0"
   }
 }

--- a/spec/utilSpec.js
+++ b/spec/utilSpec.js
@@ -1,0 +1,28 @@
+const util = require("../lib/util");
+
+describe("util", function() {
+  describe("isHtml", function() {
+    it("detects no extension", function() {
+      expect(util.isHtml("/")).toBe(true);
+    });
+    it("detects html", function() {
+      expect(util.isHtml("index.html")).toBe(true);
+    });
+    it("detects htm", function() {
+      expect(util.isHtml("index.htm")).toBe(true);
+    });
+    it("detects double dot html", function() {
+      expect(util.isHtml("index.bak.html")).toBe(true);
+    });
+    it("does not detect js", function() {
+      expect(util.isHtml("index.js")).toBe(false);
+    });
+    it("handles miscellaneous dots", function() {
+      expect(
+        util.isHtml(
+          "categories/1234;lat=-999999.8888888;lng=12341234.13371337;location=SanFrancisco"
+        )
+      ).toBe(true);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1300,9 +1300,9 @@ prepend-http@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
 
-prerendercloud@^1.23.2:
-  version "1.23.2"
-  resolved "https://registry.yarnpkg.com/prerendercloud/-/prerendercloud-1.23.2.tgz#297981b968b0944143b6915a91fce258964a3933"
+prerendercloud@1.27.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/prerendercloud/-/prerendercloud-1.27.0.tgz#992c64a1420aeb20c02b2c19dd740d64a5ad8cff"
   dependencies:
     debug "^2.2.0"
     got-lite "^8.0.1"


### PR DESCRIPTION
URLs that look like `/example;x=1.1234;y=hello` should still be considered an HTML path - see attached specs for more.