### PR TITLE
Env stages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ invalidate:
 	CLOUDFRONT_DISTRIBUTION_ID="${CLOUDFRONT_DISTRIBUTION_ID}" node create-invalidation.js
 
 listinvalidations:
-	aws cloudfront list-invalidations --distribution-id "" | head
+	aws cloudfront list-invalidations --distribution-id "${CLOUDFRONT_DISTRIBUTION_ID}" | tail | head -25
 
 test:
 	DEBUG=prerendercloud PRERENDER_SERVICE_URL="https://service.prerender.cloud" ./node_modules/jasmine/bin/jasmine.js

--- a/deploy.js
+++ b/deploy.js
@@ -8,8 +8,8 @@ const viewjoin = 'Lambda-Edge-Prerendercloud-' + process.env["color"] + '-viewer
 const originjoin = 'Lambda-Edge-Prerendercloud-' + process.env["color"] + '-originRequest';
 const originName1 = process.env["originName"];
 const viewerName1 = process.env["viewerName"];
-const viewer = viewjoin + ':' + viewerName1;
-const origin = originjoin + ':' + originName1;
+const viewer = viewjoin //+ ':' + viewerName1;
+const origin = originjoin //+ ':' + originName1;
 console.log(viewer);
 console.log(origin);
 

--- a/deploy.js
+++ b/deploy.js
@@ -4,16 +4,26 @@ if (!process.env["CLOUDFRONT_DISTRIBUTION_ID"]) {
 
 CLOUDFRONT_DISTRIBUTION_ID = process.env["CLOUDFRONT_DISTRIBUTION_ID"];
 
+const viewjoin = 'Lambda-Edge-Prerendercloud-' + process.env["color"] + '-viewerRequest';
+const originjoin = 'Lambda-Edge-Prerendercloud-' + process.env["color"] + '-originRequest';
+const originName1 = process.env["originName"];
+const viewerName1 = process.env["viewerName"];
+const viewer = viewjoin + ':' + viewerName1;
+const origin = originjoin + ':' + originName1;
+console.log(viewer);
+console.log(origin);
+
 const lambdaMappings = [
   {
-    FunctionName: "Lambda-Edge-Prerendercloud-dev-viewerRequest",
+    FunctionName: viewer,
     EventType: "viewer-request"
   },
   {
-    FunctionName: "Lambda-Edge-Prerendercloud-dev-originRequest",
+    FunctionName: origin,
     EventType: "origin-request"
   }
 ];
+console.log(lambdaMappings);
 
 const AWS = require("aws-sdk");
 AWS.config.region = "us-east-1";

--- a/handler.js
+++ b/handler.js
@@ -21,7 +21,7 @@ const resetPrerenderCloud = () => {
   // 1. prerenderToken (API token, you'll be rate limited without it)
   //    Get it after signing up at https://www.prerender.cloud/
   //    note: Lambda@Edge doesn't support env vars, so hardcoding is your only option.
-  // prerendercloud.set("prerenderToken", "mySecretToken")
+  prerendercloud.set("prerenderToken", "dXMtd2VzdC0yOjRiZTNlN2M0LWJjZDEtNDE3NC04YjFmLTA5YTVlZjE3OGFkYw.yJp3DFlWZPZoe7CrXbuJcf1fE8NQNLeyrYydGTVy-hI")
 
   // 2. protocol (optional, default is https)
   //    use this to force a certain protocol for requests from service.prerender.cloud to your origin
@@ -35,7 +35,7 @@ const resetPrerenderCloud = () => {
   //    set it, the only info we'd have access to during Lambda@Edge runtime is the host of the origin (S3)
   //    which would require additional configuration to make it publicly accessible (and it just makes things more confusing).
   //    example value: example.com or d1pxreml448ujs.cloudfront.net (don't include the protocol)
-  // prerendercloud.set("host", "");
+  prerendercloud.set("host", "green.curatedby.com");
 
   // 4. removeTrailingSlash (recommended)
   //    Removes trailing slash from URLs to increase prerender.cloud server cache hit rate

--- a/handler.js
+++ b/handler.js
@@ -21,7 +21,7 @@ const resetPrerenderCloud = () => {
   // 1. prerenderToken (API token, you'll be rate limited without it)
   //    Get it after signing up at https://www.prerender.cloud/
   //    note: Lambda@Edge doesn't support env vars, so hardcoding is your only option.
-  prerendercloud.set("prerenderToken", "dXMtd2VzdC0yOjRiZTNlN2M0LWJjZDEtNDE3NC04YjFmLTA5YTVlZjE3OGFkYw.yJp3DFlWZPZoe7CrXbuJcf1fE8NQNLeyrYydGTVy-hI")
+  prerendercloud.set("prerenderToken", "")
 
   // 2. protocol (optional, default is https)
   //    use this to force a certain protocol for requests from service.prerender.cloud to your origin
@@ -35,7 +35,7 @@ const resetPrerenderCloud = () => {
   //    set it, the only info we'd have access to during Lambda@Edge runtime is the host of the origin (S3)
   //    which would require additional configuration to make it publicly accessible (and it just makes things more confusing).
   //    example value: example.com or d1pxreml448ujs.cloudfront.net (don't include the protocol)
-  prerendercloud.set("host", "green.curatedby.com");
+  prerendercloud.set("host", "<red.test.com ex:DNS>");
 
   // 4. removeTrailingSlash (recommended)
   //    Removes trailing slash from URLs to increase prerender.cloud server cache hit rate

--- a/serverless.yml
+++ b/serverless.yml
@@ -15,12 +15,12 @@ provider:
   role: LambdaEdgeRole
 
 # you can overwrite defaults here
-#  stage: dev
+  stage: ${env:stage}
 
 # you can define service wide environment variables here
-#  environment:
-#    variable1: value1
-
+  environment:
+    viewerName: dev    
+    originName: dev
 # you can add packaging information here
 #package:
 #  include:
@@ -31,7 +31,7 @@ provider:
 #    - exclude-me-dir/**
 
 functions:
-  viewerRequest:
+  viewerRequest: 
     handler: handler.viewerRequest
     timeout: 5
   originRequest:
@@ -57,7 +57,7 @@ resources:
         Policies:
           - PolicyName: LambdaEdgeExecutionRole
             PolicyDocument:
-              Version: "2012-10-17"
+#              Version: "2012-10-17"
               Statement:
                 - Effect: Allow
                   Action:


### PR DESCRIPTION
Please test as a Feature Integration:

Support for Environment Stages and Colors
  We have Red, Yellow, Blue, and Green Deployment Environments
   Red - Dev | Yellow - Stage/Test | Blue/Green - Prod/QA

Added supported environment variables:
color="red"
stage="dev"

This allows for multiple Lambda Function names as well

Adding the host as a CNAME to Cloudfront works:
Ex:  red.test.com  CNAME/Alias   d42mp9zdib7he3.cloudfront.net


==================================================
Proof run:

Successfully associated Lambda functions with CloudFront


CLOUDFRONT_DISTRIBUTION_ID="E2NLPLVW7TK8BE" node create-invalidation.js
{ Location: 'https://cloudfront.amazonaws.com/2017-03-25/distribution/E2NLPLVW7TK8BE/invalidation/I124JZO7DAUL8C',
  Invalidation:
   { Id: 'I124JZO7DAUL8C',
     Status: 'InProgress',
     CreateTime: 2018-03-19T17:48:02.874Z,
     InvalidationBatch: { Paths: [Object], CallerReference: '2018-03-19T17:48:02.311Z' } } }
colony005:pre-red Fitch$ make deploy
node ./validate.js
./node_modules/.bin/serverless deploy
Serverless: Packaging service...
Serverless: Excluding development dependencies...
Serverless: Service files not changed. Skipping deployment...
Service Information
service: Lambda-Edge-Prerendercloud
stage: red
region: us-east-1
stack: Lambda-Edge-Prerendercloud-red
api keys:
  None
endpoints:
  None
functions:
  viewerRequest: Lambda-Edge-Prerendercloud-red-viewerRequest
  originRequest: Lambda-Edge-Prerendercloud-red-originRequest
CLOUDFRONT_DISTRIBUTION_ID="E2NLPLVW7TK8BE" node deploy.js
Lambda-Edge-Prerendercloud-red-viewerRequest
Lambda-Edge-Prerendercloud-red-originRequest
[ { FunctionName: 'Lambda-Edge-Prerendercloud-red-viewerRequest',
    EventType: 'viewer-request' },
  { FunctionName: 'Lambda-Edge-Prerendercloud-red-originRequest',
    EventType: 'origin-request' } ]
before []
after [ { EventType: 'viewer-request',
    LambdaFunctionARN: 'arn:aws:lambda:us-east-1:422025336571:function:Lambda-Edge-Prerendercloud-red-viewerRequest:49' },
  { EventType: 'origin-request',
    LambdaFunctionARN: 'arn:aws:lambda:us-east-1:422025336571:function:Lambda-Edge-Prerendercloud-red-originRequest:49' } ]