### PR TITLE
Return latest lambda function with explicit version number

### DIFF
--- a/deploy.js
+++ b/deploy.js
@@ -44,9 +44,10 @@ const getLatestVersion = lambdaMapping =>
   getLastPageOfVersions(lambdaMapping)
     .then(
       res =>
-        res.Versions.sort(
-          (a, b) => (parseInt(a.Version) > parseInt(b.Version) ? -1 : 1)
-        )[0]
+        res.Versions.reduce((prev, curr) => (
+          isNaN(curr.Version)
+          || parseInt(prev.Version) > parseInt(curr.Version) ? prev : curr
+        ))
     )
     .then(latest => ({
       EventType: lambdaMapping.EventType,


### PR DESCRIPTION
Function with "$Latest" tag as version always gets returned. The function ARN must reference a specific function version to be associated with Cloudfront.